### PR TITLE
small refactor to improve perf a little

### DIFF
--- a/postgresql_lock/lock.py
+++ b/postgresql_lock/lock.py
@@ -95,8 +95,9 @@ class Lock:
         self.interface = interface
         self.impl = self._load_impl()
         self.key = key
-        self.lock_id = int(
-            str(int(hashlib.sha1(str(key).encode("utf-8")).hexdigest(), 16))[:18]
+        self.lock_id = (
+            int.from_bytes(hashlib.sha1(str(key).encode("utf-8")).digest())
+            // 10000000000000000000000000000000
         )
         self.rollback_on_error = rollback_on_error
         self.scope = scope


### PR DESCRIPTION
this generate same id as before.

But i think we should just use `int.from_bytes(hashlib.sha1(str(key).encode("utf-8")).digest()[:8], byteorder="big", signed=True)` to fit in pg bigint, which is a int64.